### PR TITLE
Fix proximity in low power proximity

### DIFF
--- a/drivers/input/touchscreen/novatek/nt36525/nt36xxx.c
+++ b/drivers/input/touchscreen/novatek/nt36525/nt36xxx.c
@@ -1719,6 +1719,7 @@ void nvt_ts_proximity_report(uint8_t *data)
 {
 	struct nvt_ts_event_proximity *p_event_proximity;
 	u8 status = 0;
+	u8 status_inv = 5;
 
 	 p_event_proximity = (struct nvt_ts_event_proximity *)&data[1];
 
@@ -1729,13 +1730,17 @@ void nvt_ts_proximity_report(uint8_t *data)
 	}
 
 	status = p_event_proximity->status;
-	status = !status;
+	if ( status == 0 || status == 5 ) {
+		status_inv = 5;
+	} else if ( status > 0 || status < 5 ) {
+		status_inv = 0;
+	}
 
 	input_info(true, &ts->client->dev,"proximity->status = %d\n", status);
 
-	input_info(true, &ts->client->dev, "%s hover : %d\n", __func__, status);
-	ts->hover_event = status;
-	input_report_abs(ts->input_dev_proximity, ABS_MT_CUSTOM, status);
+	input_info(true, &ts->client->dev, "%s hover : %d\n", __func__, status_inv);
+	ts->hover_event = status_inv;
+	input_report_abs(ts->input_dev_proximity, ABS_MT_CUSTOM, status_inv);
 	input_sync(ts->input_dev_proximity);
 
 #if 0


### PR DESCRIPTION
Android considers the values 1->5 to be a released proximity event and 0 to be a triggered event. Meanwhile the driver reports 1 -> 3 when proximity is triggered when the screen is powered on and 0 when proximity is released. When in low power proximity mode, the driver reports 4 for a triggered proximity event and 5 for a released proximity event. This patch solves this by reporting 0 when the value would be reported as 1->4 and 5 when the value is either 0 or 5.